### PR TITLE
Fix dataset repo and workflow push

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,0 +1,41 @@
+name: Fetch Tuchtrecht Data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+        - name: Run fetch script
+          env:
+            HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          run: python fetch_tuchtrecht.py
+
+        - name: Commit new data
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add data/*.xml
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
+            else
+              git commit -m "Update tuchtrecht data"
+              git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
+            fi

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This project fetches daily data from the Tuchtrecht SRU endpoint provided by the
 
 ## Setup
 
+Use Python 3.11 which has pre-built wheels for all dependencies:
+
 ```bash
-pip install -r requirements.txt
+python3.11 -m pip install -r requirements.txt
 ```
 
 ## Daily Fetch Script
@@ -23,4 +25,14 @@ Or add to cron to automate daily.
 
 ## Hugging Face
 
-Make sure to set your token and dataset repo name in `fetch_tuchtrecht.py`.
+Set the following environment variables before running the fetch script:
+
+* `HF_TOKEN` – an access token with write permissions
+
+The dataset will be created under `vGassen/Dutch-Disciplinary-Law-Tuchtrecht`.
+
+## GitHub Actions
+
+A workflow is included to automate fetching. It runs every Sunday and can also
+be triggered manually from the Actions tab. Configure the `HF_TOKEN` secret in
+your repository settings so the script can push the latest data to Hugging Face.

--- a/fetch_tuchtrecht.py
+++ b/fetch_tuchtrecht.py
@@ -1,0 +1,87 @@
+import os
+import requests
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from pathlib import Path
+from datasets import Dataset
+from huggingface_hub import HfApi, login
+
+# Directory for downloaded XML files
+REPO_DIR = Path(__file__).resolve().parent
+DATA_DIR = REPO_DIR / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+# Output file named with today's date
+TODAY = datetime.today().strftime("%Y-%m-%d")
+FILENAME = f"tuchtrecht_{TODAY}.xml"
+OUTPUT_FILE = DATA_DIR / FILENAME
+
+# SRU endpoint parameters
+URL = "https://repository.overheid.nl/sru"
+PARAMS = {
+    "version": "2.0",
+    "operation": "searchRetrieve",
+    "x-connection": "tuchtrecht",
+    "query": "cql.allRecords=1",
+    "maximumRecords": "100",
+}
+
+NS = {
+    "gzd": "http://standaarden.overheid.nl/sru/gzd/1.0",
+    "dcterms": "http://purl.org/dc/terms/",
+}
+
+# Dataset on Hugging Face to push the records to
+HF_REPO_ID = "vGassen/Dutch-Disciplinary-Law-Tuchtrecht"
+
+
+def fetch_xml() -> bytes:
+    """Download XML records from the SRU endpoint."""
+    resp = requests.get(URL, params=PARAMS, timeout=20)
+    resp.raise_for_status()
+    return resp.content
+
+
+def parse_records(xml_content: bytes) -> list[dict]:
+    """Parse SRU XML and extract ECLI and original XML."""
+    root = ET.fromstring(xml_content)
+    records = []
+    for record in root.findall(".//gzd:record", NS):
+        identifier = record.find(".//dcterms:identifier", NS)
+        original_data = record.find(".//gzd:originalData", NS)
+        if identifier is None or original_data is None:
+            continue
+        ecli = identifier.text.strip()
+        xml_str = ET.tostring(original_data, encoding="unicode")
+        records.append({
+            "URL": f"https://tuchtrecht.overheid.nl/{ecli}",
+            "xml": xml_str,
+            "source": "Tuchtrecht",
+        })
+    return records
+
+
+def push_dataset(records: list[dict]):
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        print("HF_TOKEN not provided")
+        return
+    login(token=token)
+    ds = Dataset.from_list(records)
+    api = HfApi()
+    api.create_repo(repo_id=HF_REPO_ID, repo_type="dataset", exist_ok=True)
+    ds.push_to_hub(HF_REPO_ID, private=False)
+
+
+def main():
+    xml_content = fetch_xml()
+    OUTPUT_FILE.write_bytes(xml_content)
+    records = parse_records(xml_content)
+    if records:
+        push_dataset(records)
+    else:
+        print("No records parsed")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
 huggingface_hub
+datasets
 scrapy==2.11.1
 pandas==2.2.2


### PR DESCRIPTION
## Summary
- update `fetch_tuchtrecht.py` to always push to `vGassen/Dutch-Disciplinary-Law-Tuchtrecht`
- clarify dataset name in README
- update workflow to use `GITHUB_TOKEN` for pushing changes

## Testing
- `python -m py_compile fetch_tuchtrecht.py scrape_and_push.py`


------
https://chatgpt.com/codex/tasks/task_e_6851a242d4fc8329981cabee2da97b5b