### PR TITLE
Shard crawler output and limit runs

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -28,12 +28,12 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_REPO:  ${{ secrets.HF_REPO }}
-        run: python fetch_tuchtrecht.py
+        run: python fetch_tuchtrecht.py --limit 5000
 
       - name: Commit progress artefacts
         run: |
           git config user.name "github-actions"
           git config user.email "actions@users.noreply.github.com"
-          git add visited.txt tuchtrecht.jsonl || true
+          git add visited.txt || true
           git diff --cached --quiet || git commit -m "Update dataset ($(date -u))"
           git push

--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ python3.11 -m pip install -r requirements.txt
 
 ## Daily Fetch Script
 
-Run manually:
+Run manually (the crawler fetches up to 5000 new rulings per run):
 
 ```bash
 python fetch_tuchtrecht.py
 ```
+
+Each run writes a new JSONL file under `shards/` and uploads it to the
+configured Hugging Face dataset.
 
 Or add to cron to automate daily.
 


### PR DESCRIPTION
## Summary
- shard tuchtrecht data into `shards/` JSONL files
- add `--limit` parameter with default 5000
- upload each shard to HF and adjust workflow commit step
- update README

## Testing
- `python -m py_compile fetch_tuchtrecht.py`

------
https://chatgpt.com/codex/tasks/task_e_6853f6e9068c8329b8c4cd8eb2333efe