### PR TITLE
Fix crawler shards and text cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Use `python fetch_tuchtrecht.py --hard-reset` to delete existing checkpoints
 (`visited.txt` and any JSON shards) and crawl everything again.
 
 Each run writes a new JSONL file under `shards/` and uploads it to the
-configured Hugging Face dataset.
+configured Hugging Face dataset. The current shard number is stored in
+`last_shard.txt` so consecutive runs don't overwrite previous data.
 
 Or add to cron to automate daily.
 


### PR DESCRIPTION
## Summary
- avoid overwriting HF shards by persisting the shard index in `last_shard.txt`
- improve header/footer stripping to avoid leftover boilerplate
- document new shard index file in the README

## Testing
- `python -m py_compile fetch_tuchtrecht.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e0d851688329a024e404fb896a8b