### PR TITLE
Refactor crawler and add tests

### DIFF
--- a/crawler_base.py
+++ b/crawler_base.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import os
+import time
+import re
+from pathlib import Path
+from typing import Iterable, Iterator, List, Dict, Set
+
+import requests
+from bs4 import BeautifulSoup
+from lxml import etree
+from requests.adapters import HTTPAdapter, Retry
+from datasets import Dataset, Features, Value
+from tqdm import tqdm
+from huggingface_hub import HfApi
+
+
+class BaseCrawler:
+    """Common utilities for disciplined crawlers."""
+
+    def __init__(self, base_url: str, delay: float = 0.3, visited_file: str = "visited_xmls.txt"):
+        self.base_url = base_url.rstrip("/")
+        self.delay = delay
+        self.visited_file = Path(visited_file)
+        self.session = self._build_session()
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def _build_session(self) -> requests.Session:
+        sess = requests.Session()
+        retries = Retry(total=5, backoff_factor=1.5, status_forcelist=[500, 502, 503, 504])
+        sess.mount("https://", HTTPAdapter(max_retries=retries))
+        sess.headers.update({"User-Agent": "ESJ-Tuchtrecht-Scraper/1.0"})
+        return sess
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def fetch_soup(self, path: str) -> BeautifulSoup:
+        url = f"{self.base_url}{path}"
+        for _ in range(3):
+            try:
+                res = self.session.get(url, timeout=30)
+                res.raise_for_status()
+                return BeautifulSoup(res.text, "lxml")
+            except Exception as e:
+                self.log.warning(json.dumps({"url": url, "error": str(e), "phase": "fetch"}))
+                time.sleep(self.delay * 2)
+        raise RuntimeError(f"Failed after retries: {url}")
+
+    def strip_xml(self, xml_bytes: bytes) -> str:
+        parser = etree.XMLParser(recover=True, encoding="utf-8")
+        root = etree.fromstring(xml_bytes, parser=parser)
+        text = " ".join(chunk.strip() for chunk in root.itertext() if chunk.strip())
+        # remove closing paragraphs containing names
+        text = re.sub(r"Aldus.*?(?:voorzitter|secretaris).*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"w\.g\.\s*", "", text, flags=re.IGNORECASE)
+        return text.strip()
+
+    def load_visited(self) -> Set[str]:
+        if not self.visited_file.exists():
+            return set()
+        return set(self.visited_file.read_text(encoding="utf-8").splitlines())
+
+    def append_visited(self, urls: Iterable[str]) -> None:
+        if not urls:
+            return
+        with self.visited_file.open("a", encoding="utf-8") as f:
+            for u in urls:
+                f.write(u + "\n")
+
+    def push_dataset(self, records: Iterable[Dict[str, str]], repo: str, token: str, private: bool = False) -> None:
+        data = list(records)
+        if not data:
+            self.log.info("No data to push")
+            return
+        features = Features({"url": Value("string"), "content": Value("string"), "source": Value("string")})
+        ds = Dataset.from_list(data, features=features)
+        api = HfApi(token=token)
+        api.create_repo(repo_id=repo, repo_type="dataset", exist_ok=True)
+        ds.push_to_hub(repo_id=repo, token=token, split="train", private=private, max_shard_size="500MB")
+        self.log.info("Uploaded %d rows to %s", len(data), repo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ huggingface_hub>=0.23.0
 lxml>=5.2.1
 requests>=2.32.2
 tqdm>=4.66.4
+pytest>=7.0

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,8 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import re
+from tuchtrecht_crawler import TuchtrechtCrawler
+
+def test_xml_pattern():
+    pattern = TuchtrechtCrawler.XML_PATTERN
+    assert pattern.match('/frbr/tuchtrecht/1994/ECLI-ABC/ocrxml')
+    assert not pattern.match('/frbr/tuchtrecht/1994/ECLI-ABC')

--- a/tests/test_strip.py
+++ b/tests/test_strip.py
@@ -1,0 +1,8 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from crawler_base import BaseCrawler
+
+def test_strip_xml_removes_names():
+    crawler = BaseCrawler('https://example.com')
+    xml = b'<root><p>Some text</p><p>Aldus gegeven door mr. X, voorzitter w.g.</p></root>'
+    text = crawler.strip_xml(xml)
+    assert 'Aldus' not in text

--- a/tuchtrecht_crawler.py
+++ b/tuchtrecht_crawler.py
@@ -1,0 +1,103 @@
+import argparse
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable, Iterator, List, Dict
+
+from tqdm import tqdm
+import requests
+from huggingface_hub import HfApi
+
+from crawler_base import BaseCrawler
+
+
+class TuchtrechtCrawler(BaseCrawler):
+    ROOT_PATH = "/frbr/tuchtrecht"
+    PAGE_SIZE = 11
+    XML_PATTERN = re.compile(r"^/frbr/tuchtrecht/[12]\d{3}/[A-Z0-9\-]+/ocrxml$")
+
+    def __init__(self, base_url: str, delay: float, repo: str, max_items: int, workers: int = 1):
+        super().__init__(base_url, delay)
+        self.repo = repo
+        self.max_items = max_items
+        self.workers = workers
+
+    def iter_paths(self) -> Iterator[str]:
+        offset = 0
+        while True:
+            path = f"{self.ROOT_PATH}?start={offset}" if offset else self.ROOT_PATH
+            soup = self.fetch_soup(path)
+            links = [a.get("href", "") for a in soup.select("a[href^='/frbr/tuchtrecht/']")]
+            paths = [href for href in links if self.XML_PATTERN.match(href)]
+            if not paths:
+                break
+            for p in paths:
+                yield p
+            offset += self.PAGE_SIZE
+            time.sleep(self.delay)
+
+    def extract_xml(self, path: str) -> Dict[str, str] | None:
+        try:
+            url = f"{self.base_url}{path}"
+            resp = self.session.get(url, timeout=60)
+            resp.raise_for_status()
+            text = self.strip_xml(resp.content)
+            return {"url": url, "content": text, "source": "Tuchtrechtspraak"}
+        except Exception as e:
+            self.log.error("Error fetching %s: %s", path, e)
+            return None
+
+    def crawl(self) -> List[Dict[str, str]]:
+        visited = self.load_visited()
+        records: List[Dict[str, str]] = []
+        new_seen: List[str] = []
+
+        paths = list(self.iter_paths())
+        bar = tqdm(paths, desc="XML links")
+        for path in bar:
+            url = f"{self.base_url}{path}"
+            if url in visited:
+                continue
+            if len(records) >= self.max_items:
+                break
+            rec = self.extract_xml(path)
+            if rec:
+                records.append(rec)
+                new_seen.append(url)
+            if len(new_seen) >= 50:
+                self.append_visited(new_seen)
+                new_seen.clear()
+        if new_seen:
+            self.append_visited(new_seen)
+        return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Tuchtrecht crawler")
+    parser.add_argument("--limit", type=int, default=500, help="max documents")
+    parser.add_argument("--delay", type=float, default=0.3, help="delay between requests")
+    parser.add_argument("--repo", type=str, default=os.getenv("HF_DATASET_REPO", ""))
+    parser.add_argument("--workers", type=int, default=1, help="parallel downloads")
+    parser.add_argument("--resume", action="store_true", help="resume from visited log")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    crawler = TuchtrechtCrawler(
+        base_url="https://repository.overheid.nl",
+        delay=args.delay,
+        repo=args.repo,
+        max_items=args.limit,
+        workers=args.workers,
+    )
+
+    records = crawler.crawl()
+    if args.repo and os.getenv("HF_TOKEN"):
+        crawler.push_dataset(records, args.repo, os.getenv("HF_TOKEN"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `BaseCrawler` with reusable HTTP, logging and text cleaning helpers
- implement `TuchtrechtCrawler` using new base with offset-based pagination
- allow CLI parameters for limit, delay and repo
- strip closing paragraphs that contain names
- add minimal unit tests
- include `pytest` in requirements

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685af5cd6f3c8329846ed9d547de8221