### PR TITLE
Fix module import path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ python3.11 -m pip install -r requirements.txt
 Run manually (the crawler fetches up to 5000 new rulings per run):
 
 ```bash
-python main.py
+python -m crawler.main
 ```
 
-Use `python main.py --resume` to continue from the last visited log instead of
+Use `python -m crawler.main --resume` to continue from the last visited log instead of
 starting a fresh crawl.
 
 Each run writes a new JSONL file under `shards/` and uploads it to the

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -2,8 +2,16 @@
 # Main entry point for the Tuchtrecht crawler.
 
 import os
+import sys
+from pathlib import Path
 from datetime import datetime, timezone
 import jsonlines
+
+# Ensure the package is importable when executed directly as a script.
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from crawler.sru_client import get_records
 from crawler.parser import parse_record
 from crawler.scrubber import scrub_text


### PR DESCRIPTION
## Summary
- ensure crawler imports work even when executing via `python crawler/main.py`
- clarify README instructions on how to run the crawler

## Testing
- `python -m pip install -r requirements.txt`
- `python crawler/main.py` *(fails to fetch due to 403 Forbidden but runs)*

------
https://chatgpt.com/codex/tasks/task_e_685e75d687248329b7da81a086694b1a