### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 2 * * 0'
 
+permissions:
+  contents: write
+
 jobs:
   crawl:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow Github Actions to push to `main`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e788f7fe48329a8c47650b5f638ac