### PR TITLE
Improve crawler HTTP reliability

### DIFF
--- a/crawler/parser.py
+++ b/crawler/parser.py
@@ -2,21 +2,25 @@
 # This module is responsible for parsing the XML responses from the SRU endpoint.
 
 from typing import Dict, Any, Optional
+
 import requests
+
+from .utils import get_session
+
+_SESSION = get_session()
 
 def get_full_text(url: str) -> Optional[str]:
     """
-    Fetches the full text content from a given URL.
-    It expects the content to be XML and will extract text from it.
-    
+    Fetches the full text content from a given URL using a session with retry.
+
     Args:
         url: The URL of the XML file.
-        
+
     Returns:
         The extracted full text as a string, or None if fetching fails.
     """
     try:
-        response = requests.get(url)
+        response = _SESSION.get(url)
         response.raise_for_status()
         # We assume the content is XML and needs parsing to extract text.
         # This is a simple text extraction. More complex XML structures might need a more robust parser.

--- a/crawler/sru_client.py
+++ b/crawler/sru_client.py
@@ -1,8 +1,13 @@
 # crawler/sru_client.py
 # This module handles all SRU 2.0 protocol communication.
 
-import requests
 from typing import Iterator, Dict, Any
+
+import requests
+
+from .utils import get_session
+
+_SESSION = get_session()
 
 BASE_URL = "https://repository.overheid.nl/sru"
 PAGE_SIZE = 100 # As per SRU documentation, max is 1000, but we'll use a smaller size
@@ -35,7 +40,7 @@ def get_records(query: str, start_date: str = None) -> Iterator[Dict[str, Any]]:
         }
         
         try:
-            response = requests.get(BASE_URL, params=params)
+            response = _SESSION.get(BASE_URL, params=params)
             response.raise_for_status()
             
             import xmltodict

--- a/crawler/utils.py
+++ b/crawler/utils.py
@@ -1,0 +1,18 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def get_session() -> requests.Session:
+    """Return a requests session with retry policy for transient errors."""
+    retries = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session


### PR DESCRIPTION
## Summary
- add utility for HTTP sessions with retry policy
- use shared session in record fetching and full text download

## Testing
- `python -m py_compile crawler/*.py`
- `pip install -r requirements.txt` *(fails: domain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e7bf201e883298118fbe54c21bd65