### PR TITLE
Enable manual backlog crawl

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -31,7 +31,12 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run crawler
-        run: python crawler/main.py
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            python crawler/main.py --reset
+          else
+            python crawler/main.py
+          fi
 
       - name: Commit and push if it changed
         run: |

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Run manually (the crawler fetches up to 5000 new rulings per run):
 python -m crawler.main
 ```
 
-Use `python -m crawler.main --resume` to continue from the last visited log instead of
-starting a fresh crawl.
+Use `python -m crawler.main --reset` to ignore the last run timestamp and crawl the
+entire backlog.
 
 Each run writes a new JSONL file under `shards/` and uploads it to the
 configured Hugging Face dataset. The current shard number is stored in

--- a/crawler/main.py
+++ b/crawler/main.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from datetime import datetime, timezone
 import jsonlines
+import argparse
 
 # Ensure the package is importable when executed directly as a script.
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -21,56 +22,80 @@ LAST_UPDATE_FILE = ".last_update"
 BASE_QUERY = "c.product-area==tuchtrecht"
 RECORDS_PER_SHARD = 1000
 
+
 def get_last_run_date():
     """Reads the last run timestamp from the .last_update file."""
     if os.path.exists(LAST_UPDATE_FILE):
-        with open(LAST_UPDATE_FILE, 'r') as f:
+        with open(LAST_UPDATE_FILE, "r") as f:
             return f.read().strip()
     return None
 
+
 def save_last_run_date():
     """Saves the current timestamp to the .last_update file."""
-    with open(LAST_UPDATE_FILE, 'w') as f:
+    with open(LAST_UPDATE_FILE, "w") as f:
         f.write(datetime.now(timezone.utc).isoformat())
 
-def main():
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run the Tuchtrecht crawler")
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Ignore the last update timestamp and crawl the full backlog",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
     """Main function to run the crawler."""
+    args = parse_args()
+
+    if args.reset and os.path.exists(LAST_UPDATE_FILE):
+        os.remove(LAST_UPDATE_FILE)
+
     if not os.path.exists(DATA_DIR):
         os.makedirs(DATA_DIR)
 
-    last_run_date = get_last_run_date()
-    
+    last_run_date = None if args.reset else get_last_run_date()
+
     if last_run_date:
         print(f"Performing weekly update since last run on: {last_run_date}")
     else:
         print("Performing full backlog crawl.")
 
     records_iterator = get_records(BASE_QUERY, start_date=last_run_date)
-    
+
     shard_index = 0
     records_in_current_shard = 0
-    
+
     # Find the latest shard index to append to it.
-    existing_shards = [f for f in os.listdir(DATA_DIR) if f.startswith("tuchtrecht_shard_")]
+    existing_shards = [
+        f for f in os.listdir(DATA_DIR) if f.startswith("tuchtrecht_shard_")
+    ]
     if existing_shards:
-        shard_index = max([int(f.split('_')[-1].split('.')[0]) for f in existing_shards])
+        shard_index = max(
+            [int(f.split("_")[-1].split(".")[0]) for f in existing_shards]
+        )
         # Check if the latest shard is full
-        with jsonlines.open(os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")) as reader:
+        with jsonlines.open(
+            os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")
+        ) as reader:
             records_in_current_shard = sum(1 for _ in reader)
         if records_in_current_shard >= RECORDS_PER_SHARD:
             shard_index += 1
             records_in_current_shard = 0
 
-
     output_file = os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")
-    writer = jsonlines.open(output_file, mode='a')
+    writer = jsonlines.open(output_file, mode="a")
 
     processed_count = 0
     for record in records_iterator:
         parsed = parse_record(record)
         if parsed:
-            parsed['Content'] = scrub_text(parsed['Content'])
-            
+            parsed["Content"] = scrub_text(parsed["Content"])
+
             writer.write(parsed)
             processed_count += 1
             records_in_current_shard += 1
@@ -79,15 +104,18 @@ def main():
                 writer.close()
                 shard_index += 1
                 records_in_current_shard = 0
-                output_file = os.path.join(DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl")
-                writer = jsonlines.open(output_file, mode='w')
-                
+                output_file = os.path.join(
+                    DATA_DIR, f"tuchtrecht_shard_{shard_index:03d}.jsonl"
+                )
+                writer = jsonlines.open(output_file, mode="w")
+
     writer.close()
-    
+
     print(f"Processed and saved {processed_count} records.")
 
     if processed_count > 0 or not last_run_date:
         save_last_run_date()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `--reset` command line option for crawler
- run backlog crawl only on manual workflow dispatch
- document reset flag in README

## Testing
- `pip install -r requirements.txt`
- `python crawler/main.py --help`
- `python -m py_compile crawler/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685e7e8a17488329a3dd2ad5a4d02633