### PR TITLE
Add Hugging Face upload via workflow

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -46,3 +46,17 @@ jobs:
           # Commit only if there are changes
           git diff --staged --quiet || git commit -m "Weekly Tuchtrecht data update"
           git push
+
+      - name: Upload data to Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_DATASET_REPO: ${{ secrets.HF_DATASET_REPO }}
+        run: |
+          pip install huggingface_hub git-lfs
+          git lfs install
+          git clone https://huggingface.co/datasets/${HF_DATASET_REPO} hf-dataset
+          cp data/*.jsonl hf-dataset/ || true
+          cd hf-dataset
+          git add .
+          git commit -m "Update dataset from crawler run" || echo "No changes"
+          git push https://user:${HF_TOKEN}@huggingface.co/datasets/${HF_DATASET_REPO} HEAD

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Tuchtrecht (disciplinary law) corpus spans multiple professional fields:
 The crawler performs the following steps:
 
 1. Saves the XML to this repository.
-2. Pushes the file to Hugging Face datasets.
+2. The GitHub Actions workflow copies the generated JSONL shards to a Hugging Face dataset.
 
 ## Setup
 
@@ -60,5 +60,6 @@ The dataset will be created under `HF_DATASET_REPO`, for example
 ## GitHub Actions
 
 A workflow is included to automate fetching. It runs every Sunday and can also
-be triggered manually from the Actions tab. Configure the `HF_TOKEN` secret in
-your repository settings so the script can push the latest data to Hugging Face.
+be triggered manually from the Actions tab. Configure the `HF_TOKEN` and
+`HF_DATASET_REPO` secrets in your repository settings so the workflow can push
+the latest JSONL shards to your Hugging Face dataset.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ lxml
 xmltodict
 jsonlines
 python-dateutil
+huggingface_hub


### PR DESCRIPTION
## Summary
- upload crawler output to Hugging Face datasets
- update README with new instructions and secrets
- add `huggingface_hub` to requirements

## Testing
- `python3.11 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68627905be748329b37428a86a916609