### PR TITLE
Enable Git LFS tracking for dataset shards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jsonl filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- configure Git LFS in repository
- track all `*.jsonl` files so workflow uploads them using LFS

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6863817f08b88329b4062723bf3a300d