### PR TITLE
Fix dataset path spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Set the following environment variables before running the fetch script:
 * `HF_PRIVATE` – set to `true` to create a private dataset (optional)
 
 The dataset will be created under `HF_DATASET_REPO`, for example
-`vGassen/Dutch-Open-Data-Tuchrecht-Disciplinary-Court-Cases`.
+`vGassen/Dutch-Open-Data-Tuchtrecht-Disciplinary-Court-Cases`.
 
 ## GitHub Actions
 


### PR DESCRIPTION
## Summary
- correct spelling in README example dataset path

## Testing
- `python3 -m compileall -q crawler`

------
https://chatgpt.com/codex/tasks/task_b_686b7d64b5a8832fbceb89f4cadd67b3