### PR TITLE
Add data clearing option and limit shard size

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ the GitHub Actions log.
 
 Use `python -m crawler.main --reset` to ignore the last run timestamp and crawl the
 entire backlog. The `--max-records` option controls how many rulings are
-processed in a single run.
+processed in a single run. The `--clear-data` flag removes any existing shards
+and the `.last_update` file so the crawler starts completely fresh.
 
 Each run appends new JSONL files under `data/`. The timestamp of the last
 successful crawl is stored in `.last_update` so consecutive runs only fetch new
-data.
+data. Each shard contains at most 350 entries so the resulting files stay under
+the 10&nbsp;MiB upload limit on Hugging Face.
 
 Or add to cron to automate daily.
 


### PR DESCRIPTION
## Summary
- add `--clear-data` flag to reset existing dataset shards and timestamp
- cap shards at 350 records to stay under HF upload limit
- document shard size and clearing option

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b95f93124832f90eab1c9c3adf46c